### PR TITLE
Added `simplemono.world.core/tap` that invokes `clojure.core/tap>`

### DIFF
--- a/src/simplemono/world/core.clj
+++ b/src/simplemono/world/core.clj
@@ -48,3 +48,11 @@
    `(w< ~wrap-catch
         ~form))
   )
+
+(defn tap
+  "Invokes `clojure.core/tap>` with the world-value `w` and returns it unchanged.
+   Helpful to inspect an intermediate world-value in a `w<` or `world-reduce`
+   call."
+  [w]
+  (tap> w)
+  w)


### PR DESCRIPTION
with the world-value `w` and returns it unchanged. Helpful to inspect an intermediate world-value in a `w<` or `world-reduce` call.